### PR TITLE
Rename cover function

### DIFF
--- a/app/FeedMethods.php
+++ b/app/FeedMethods.php
@@ -7,7 +7,7 @@ return [
         return $this->podcasterAtomLink()->or($this->url());
     },
 
-    'cover' => function () {
+    'feedCover' => function () {
         if ($this->podcasterCover()->isEmpty()) {
             return null;
         }

--- a/templates/podcasterfeed.php
+++ b/templates/podcasterfeed.php
@@ -53,7 +53,7 @@ kirby()->response()->type('application/rss+xml');
         <?php snippet(
             'podcaster-feed-cover',
             [
-                'imageUrl' => $page->cover(),
+                'imageUrl' => $page->feedCover(),
                 'title' => $page->podcasterTitle(),
                 'link' => $page->podcasterLink(),
             ]


### PR DESCRIPTION
Rename to avoid conflict with other cover() functions, for example as found in ZeroOne theme. This is my first ever pull request, so be gentle ;-)