### PR TITLE
Podlove Player: hide subscribe button if clients are empty

### DIFF
--- a/app/Podcast.php
+++ b/app/Podcast.php
@@ -429,7 +429,7 @@ class Podcast
             'activeTab' => $feed->podcasterPodloveActiveTab()->value(),
             'subscribe-button' =>
                 !is_null($clients)
-                    ? [ 'feed' => $feed->url()]
+                    ? [ 'feed' => $feed->url() ]
                     : null,
         ];
 

--- a/app/Podcast.php
+++ b/app/Podcast.php
@@ -427,9 +427,10 @@ class Podcast
             'version' => 5,
             'base' => 'player/',
             'activeTab' => $feed->podcasterPodloveActiveTab()->value(),
-            'subscribe-button' => [
-                'feed' => $feed->url()
-            ],
+            'subscribe-button' =>
+                !is_null($clients)
+                    ? [ 'feed' => $feed->url()]
+                    : null,
         ];
 
         if (!is_null($tokens) || !is_null($fonts)) {


### PR DESCRIPTION
This changes the Podlove player snippet, so that the subscribe button is hidden if no clients have been added.